### PR TITLE
🩹 [Patch]: Add `PSSemVer` module

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ The Initialize-PSModule action will prepare the runner for the PSModule framewor
 
 | Module | Description |
 | --- | --- |
-| Utilities | Used by all actions, contains common function and classes such as logging, grouping and the [PSSemVer] class. |
+| Utilities | Used by all actions, contains common function and classes such as logging and grouping. |
+| PSSemVer | Used to create an object for the semantic version numbers. Has functionality to compare, and bump versions. |
 | powershell-yaml | Used to parse and serialize YAML files, typically for reading configuration files. |
 | Pester | Used for testing PowerShell code. |
 | PSScriptAnalyzer | Used to lint and format PowerShell code. |

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -3,7 +3,7 @@
 [CmdletBinding()]
 param()
 
-Install-PSResource -Name 'powershell-yaml', 'Pester', 'PSScriptAnalyzer', 'platyPS' -TrustRepository -Verbose
+Install-PSResource -Name 'powershell-yaml', 'PSSemVer', 'Pester', 'PSScriptAnalyzer', 'platyPS' -TrustRepository -Verbose
 Stop-LogGroup
 
 Start-LogGroup 'Loading helper scripts'


### PR DESCRIPTION
## Description

- Add PSSemVer as a prereq, as it is moved from `Utilities` to `PSSemVer` module.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
