### PR TITLE
🩹 [Patch]: Add inputs to override version of `Utilities`

### DIFF
--- a/.github/workflows/Action-Test.yml
+++ b/.github/workflows/Action-Test.yml
@@ -14,5 +14,28 @@ jobs:
 
       - name: Action-Test
         uses: ./
+
+  ActionTestPrerelease:
+    name: Action-Test - [Prerelease]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Action-Test
+        uses: ./
         with:
+          Prerelease: true
+
+  ActionTestVersion:
+    name: Action-Test - [Version]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Action-Test
+        uses: ./
+        with:
+          Version: '[0.1,0.2]'
           Prerelease: true

--- a/.github/workflows/Action-Test.yml
+++ b/.github/workflows/Action-Test.yml
@@ -14,3 +14,5 @@ jobs:
 
       - name: Action-Test
         uses: ./
+        with:
+          Prerelease: true

--- a/README.md
+++ b/README.md
@@ -41,11 +41,8 @@ The action can be configured using the following settings:
 
 | Name | Description | Default | Required |
 | --- | --- | --- | --- |
-| | | | |
-
-### Configuration file
-
-There are no configuration settings for the Initialize-PSModule action.
+| Version | The version of the Utilities module to install. | '' (latest) | false |
+| Prerelease | Whether to install prerelease versions of the Utilities module. | false | false |
 
 ## Example
 

--- a/action.yml
+++ b/action.yml
@@ -5,14 +5,39 @@ branding:
   icon: loader
   color: gray-dark
 
+inputs:
+  Version:
+    description: The version of the Utilities module to install.
+    required: false
+  Prerelease:
+    description: Whether to install prerelease versions of the Utilities module.
+    required: false
+    default: 'false'
+
 runs:
   using: composite
   steps:
     - name: Run Initialize-PSModule
       shell: pwsh
+      env:
+        GITHUB_ACTION_INPUT_Version: ${{ inputs.Version }}
+        GITHUB_ACTION_INPUT_Prerelease: ${{ inputs.Prerelease }}
       run: |
         # Initialize-PSModule
         Write-Host '::group::Loading modules'
-        Install-PSResource -Name 'Utilities' -TrustRepository -Verbose
+        $params = @{
+          Name            = 'Utilities'
+          Repository      = 'PSGallery'
+          TrustRepository = $true
+          PreRelease      = $env:GITHUB_ACTION_INPUT_Prerelease -eq 'true'
+          Verbose         = $true
+        }
+
+        if ([string]::IsNullOrEmpty($env:GITHUB_ACTION_INPUT_Version)) {
+          $params['Version'] = $env:GITHUB_ACTION_INPUT_Version
+        }
+
+        Install-PSResource @params
+        Write-Host '::endgroup::'
 
         . "$env:GITHUB_ACTION_PATH\scripts\main.ps1" -Verbose

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ runs:
           Verbose         = $true
         }
 
-        if ([string]::IsNullOrEmpty($env:GITHUB_ACTION_INPUT_Version)) {
+        if (-not [string]::IsNullOrEmpty($env:GITHUB_ACTION_INPUT_Version)) {
           $params['Version'] = $env:GITHUB_ACTION_INPUT_Version
         }
 


### PR DESCRIPTION
## Description

- Add inputs to override version of `Utilities`:
  - `Version` to set a version to use.
  - `Prerelease` to allow prerelease versions.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
