### PR TITLE
🚀 [Feature]: Add functionality to add environment variables into the job via StringData

### DIFF
--- a/.github/workflows/Action-Test.yml
+++ b/.github/workflows/Action-Test.yml
@@ -26,10 +26,15 @@ jobs:
         uses: ./
         with:
           env: |
-            TEST_APP_CLIENT_ID: ${{ secrets.TEST_APP_CLIENT_ID }}
-            TEST_APP_PRIVATE_KEY: ${{ secrets.TEST_APP_PRIVATE_KEY }}
-            TEST_FG_PAT: ${{ secrets.TEST_FG_PAT }}
-            TEST_PAT: ${{ secrets.TEST_PAT }}
+            TEST_APP_CLIENT_ID: qweqweqweqweqweqweqwe
+            TEST_APP_PRIVATE_KEY: |
+              -----BEGIN RSA PRIVATE KEY-----
+              qweqweqweqweqweqweqeweqweqweqweqweqweqwe
+              qweqweqweqweqweqweqweqweqweqweqweqweqweq
+              qweqweqweqweqweqweqweqweqweqweqweqweqwee
+              -----END RSA PRIVATE KEY -----
+            TEST_FG_PAT: qweqweqweqweqweqweqweqweqweqweqwe
+            TEST_PAT: qweqweqweqweqweqwe
 
       - name: Run GitHub-script
         uses: PSModule/GitHub-script@v1

--- a/.github/workflows/Action-Test.yml
+++ b/.github/workflows/Action-Test.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Action-Test
         uses: ./
-        env:
+        with:
           env1: ${{ secrets.TEST_APP_CLIENT_ID }}
           env2: ${{ secrets.TEST_APP_PRIVATE_KEY }}
           env3: ${{ secrets.TEST_FG_PAT }}

--- a/.github/workflows/Action-Test.yml
+++ b/.github/workflows/Action-Test.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           env: |
             TEST_APP_CLIENT_ID: ${{ secrets.TEST_APP_CLIENT_ID }}
-            TEST_APP_PRIVATE_KEY: ${{ secrets.TEST_APP_PRIVATE_KEY }}
+            TEST_APP_PRIVATE_KEY: ${{ toJson(secrets.TEST_APP_PRIVATE_KEY) }}
             TEST_FG_PAT: ${{ secrets.TEST_FG_PAT }}
             TEST_PAT: ${{ secrets.TEST_PAT }}
 

--- a/.github/workflows/Action-Test.yml
+++ b/.github/workflows/Action-Test.yml
@@ -24,17 +24,11 @@ jobs:
 
       - name: Action-Test
         uses: ./
-        with:
-          env: |
-            TEST_APP_CLIENT_ID: qweqweqweqweqweqweqwe
-            TEST_APP_PRIVATE_KEY: |
-              -----BEGIN RSA PRIVATE KEY-----
-              qweqweqweqweqweqweqeweqweqweqweqweqweqwe
-              qweqweqweqweqweqweqweqweqweqweqweqweqweq
-              qweqweqweqweqweqweqweqweqweqweqweqweqwee
-              -----END RSA PRIVATE KEY -----
-            TEST_FG_PAT: qweqweqweqweqweqweqweqweqweqweqwe
-            TEST_PAT: qweqweqweqweqweqwe
+        env:
+          env1: ${{ secrets.TEST_APP_CLIENT_ID }}
+          env2: ${{ secrets.TEST_APP_PRIVATE_KEY }}
+          env3: ${{ secrets.TEST_FG_PAT }}
+          env4: ${{ secrets.TEST_PAT }}
 
       - name: Run GitHub-script
         uses: PSModule/GitHub-script@v1

--- a/.github/workflows/Action-Test.yml
+++ b/.github/workflows/Action-Test.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           env: |
             TEST_APP_CLIENT_ID: ${{ secrets.TEST_APP_CLIENT_ID }}
-            TEST_APP_PRIVATE_KEY: ${{ toJson(secrets.TEST_APP_PRIVATE_KEY) }}
+            TEST_APP_PRIVATE_KEY: ${{ secrets.TEST_APP_PRIVATE_KEY }}
             TEST_FG_PAT: ${{ secrets.TEST_FG_PAT }}
             TEST_PAT: ${{ secrets.TEST_PAT }}
 

--- a/.github/workflows/Action-Test.yml
+++ b/.github/workflows/Action-Test.yml
@@ -24,6 +24,12 @@ jobs:
 
       - name: Action-Test
         uses: ./
+        with:
+          env: |
+            TEST_APP_CLIENT_ID: ${{ secrets.TEST_APP_CLIENT_ID }}
+            TEST_APP_PRIVATE_KEY: ${{ secrets.TEST_APP_PRIVATE_KEY }}
+            TEST_FG_PAT: ${{ secrets.TEST_FG_PAT }}
+            TEST_PAT: ${{ secrets.TEST_PAT }}
 
       - name: Run GitHub-script
         uses: PSModule/GitHub-script@v1
@@ -31,6 +37,7 @@ jobs:
           Script: |
             LogGroup "Run custom script" {
                 Write-Host "Hello, World!"
+                "ClientID is : [$env:TEST_APP_CLIENT_ID]"
             }
 
       - name: Run custom script

--- a/.github/workflows/Action-Test.yml
+++ b/.github/workflows/Action-Test.yml
@@ -36,7 +36,7 @@ jobs:
           Script: |
             LogGroup "Run custom script" {
                 Write-Host "Hello, World!"
-                "ClientID is : [$env:TEST_APP_CLIENT_ID]"
+                "ClientID is : [$env:env1]"
             }
 
       - name: Run custom script

--- a/README.md
+++ b/README.md
@@ -40,8 +40,11 @@ The Initialize-PSModule action will prepare the runner for the PSModule framewor
 | `Verbose` | Enable verbose output. | false | `'false'` |
 | `Version` | Specifies the version of the resource to be returned. | false |  |
 | `Prerelease` | Allow prerelease versions if available. | false | `'false'` |
+| `env` | Environment variables to set for the script. | false |  |
 
-## Example
+## Examples
+
+### Example: Basic usage
 
 The action can be used in a workflow to prepare the runner for the PSModule framework by adding it at the start of the workflow.
 
@@ -60,6 +63,30 @@ jobs:
 
       - name: Initialize environment
         uses: PSModule/Initialize-PSModule@main
+```
+
+### Example: Using the env input
+
+The action can be used in a workflow to prepare the runner for the PSModule framework by adding it at the start of the workflow.
+
+```yaml
+name: Process-PSModule
+
+on: [push]
+
+jobs:
+  Process-PSModule:
+    name: Process module
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Initialize environment
+        uses: PSModule/Initialize-PSModule@main
+        with:
+          env: |
+            MY_ENV_VAR: ${{ secrets.MY_ENV_VAR }}
 ```
 
 ## Permissions

--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ jobs:
 
 ### Example: Using the env input
 
-The action can be used in a workflow to prepare the runner for the PSModule framework by adding it at the start of the workflow.
+This action is used as a preparation step for the PSModule framework and the `Process-PSModule` reusable workflow.
+As reusable workflows do not allow passing the `env` data in, this is a usefull workaround. Provide the environment variables as a string in the
+`env` input and it will convert the data into environment variables for the job using GitHub Actions commands.
 
 ```yaml
 name: Process-PSModule
@@ -87,6 +89,7 @@ jobs:
         with:
           env: |
             MY_ENV_VAR: ${{ secrets.MY_ENV_VAR }}
+            MY_ENV_VAR2: ${{ secrets.MY_ENV_VAR2 }}
 ```
 
 ## Permissions

--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,7 @@ runs:
     - name: Initialize-PSModule
       uses: PSModule/GitHub-Script@v1
       env:
-        GITHUB_ACTION_INPUT_env: ${{ inputs.env }}
+        GITHUB_ACTION_INPUT_env: ${{ toJson(inputs.env) }}
       with:
         Debug: ${{ inputs.Debug }}
         Prerelease: ${{ inputs.Prerelease }}

--- a/action.yml
+++ b/action.yml
@@ -21,12 +21,17 @@ inputs:
     description: Allow prerelease versions if available.
     required: false
     default: 'false'
+  env:
+    description: Environment variables to set for the script.
+    required: false
 
 runs:
   using: composite
   steps:
     - name: Initialize-PSModule
       uses: PSModule/GitHub-Script@v1
+      env:
+        GITHUB_ACTION_INPUT_env: ${{ inputs.env }}
       with:
         Debug: ${{ inputs.Debug }}
         Prerelease: ${{ inputs.Prerelease }}

--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,7 @@ runs:
     - name: Initialize-PSModule
       uses: PSModule/GitHub-Script@v1
       env:
-        GITHUB_ACTION_INPUT_env: ${{ toJson(inputs.env) }}
+        GITHUB_ACTION_INPUT_env: ${{ inputs.env }}
       with:
         Debug: ${{ inputs.Debug }}
         Prerelease: ${{ inputs.Prerelease }}

--- a/action.yml
+++ b/action.yml
@@ -21,8 +21,35 @@ inputs:
     description: Allow prerelease versions if available.
     required: false
     default: 'false'
-  env:
-    description: Environment variables to set for the script.
+  env1:
+    description: Custom Environment variable to set for the script.
+    required: false
+  env2:
+    description: Custom Environment variable to set for the script.
+    required: false
+  env3:
+    description: Custom Environment variable to set for the script.
+    required: false
+  env4:
+    description: Custom Environment variable to set for the script.
+    required: false
+  env5:
+    description: Custom Environment variable to set for the script.
+    required: false
+  env6:
+    description: Custom Environment variable to set for the script.
+    required: false
+  env7:
+    description: Custom Environment variable to set for the script.
+    required: false
+  env8:
+    description: Custom Environment variable to set for the script.
+    required: false
+  env9:
+    description: Custom Environment variable to set for the script.
+    required: false
+  env10:
+    description: Custom Environment variable to set for the script.
     required: false
 
 runs:
@@ -31,7 +58,16 @@ runs:
     - name: Initialize-PSModule
       uses: PSModule/GitHub-Script@v1
       env:
-        GITHUB_ACTION_INPUT_env: ${{ inputs.env }}
+        GITHUB_ACTION_INPUT_env1: ${{ inputs.env1 }}
+        GITHUB_ACTION_INPUT_env2: ${{ inputs.env2 }}
+        GITHUB_ACTION_INPUT_env3: ${{ inputs.env3 }}
+        GITHUB_ACTION_INPUT_env4: ${{ inputs.env4 }}
+        GITHUB_ACTION_INPUT_env5: ${{ inputs.env5 }}
+        GITHUB_ACTION_INPUT_env6: ${{ inputs.env6 }}
+        GITHUB_ACTION_INPUT_env7: ${{ inputs.env7 }}
+        GITHUB_ACTION_INPUT_env8: ${{ inputs.env8 }}
+        GITHUB_ACTION_INPUT_env9: ${{ inputs.env9 }}
+        GITHUB_ACTION_INPUT_env10: ${{ inputs.env10 }}
       with:
         Debug: ${{ inputs.Debug }}
         Prerelease: ${{ inputs.Prerelease }}

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -20,7 +20,7 @@ LogGroup "Loading environment variables:" {
     $envvar = $env:GITHUB_ACTION_INPUT_env
     $data = ConvertFrom-StringData -StringData $envvar -Delimiter ':'
     $data.GetEnumerator() | ForEach-Object {
-        Write-Output "::add-mask::$($_.Value)"
+        # Write-Output "::add-mask::$($_.Value)"
         Write-Host "[$($_.Name)] = [$($_.Value)]"
         "$($_.Name)=$($_.Value)" | Out-File -FilePath $env:GITHUB_ENV -Append
     }

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -18,8 +18,6 @@ Get-PSResource -Name $requiredModules -Verbose:$false | Sort-Object -Property Na
 
 LogGroup "Loading environment variables:" {
     $envvar = $env:GITHUB_ACTION_INPUT_env
-    Write-Host "Environment variable:"
-    Write-Host $envvar
     $data = ConvertFrom-StringData -StringData $envvar -Delimiter ':'
     $data.GetEnumerator() | ForEach-Object {
         Write-Output "::add-mask::$($_.Value)"

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -15,3 +15,13 @@ $requiredModules | Sort-Object | ForEach-Object {
 
 Get-PSResource -Name $requiredModules -Verbose:$false | Sort-Object -Property Name |
     Format-Table -Property Name, Version, Prerelease, Repository -AutoSize -Wrap
+
+LogGroup "Loading environment variables:" {
+    $envvar = $env:GITHUB_ACTION_INPUT_env
+    $data = ConvertFrom-StringData -StringData $envvar -Delimiter ':'
+    $data.GetEnumerator() | ForEach-Object {
+        Write-Output "::add-mask::$($_.Value)"
+        Write-Host "[$($_.Name)] = [$($_.Value)]"
+        "$($_.Name)=$($_.Value)" | Out-File -FilePath $env:GITHUB_ENV -Append
+    }
+}

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -17,11 +17,10 @@ Get-PSResource -Name $requiredModules -Verbose:$false | Sort-Object -Property Na
     Format-Table -Property Name, Version, Prerelease, Repository -AutoSize -Wrap
 
 LogGroup "Loading environment variables:" {
-    $envvar = $env:GITHUB_ACTION_INPUT_env
-    $data = ConvertFrom-StringData -StringData $envvar -Delimiter ':'
-    $data.GetEnumerator() | ForEach-Object {
-        # Write-Output "::add-mask::$($_.Value)"
-        Write-Host "[$($_.Name)] = [$($_.Value)]"
-        "$($_.Name)=$($_.Value)" | Out-File -FilePath $env:GITHUB_ENV -Append
+    Get-ChildItem -Path env: | Where-Object { $_.Name -like 'GITHUB_ACTION_INPUT_*' } | ForEach-Object {
+        $name = $_.Name -replace '^GITHUB_ACTION_INPUT_'
+        $value = $_.Value
+        Write-Host "[$name] = [$value]"
+        "$name=$value" | Out-File -FilePath $env:GITHUB_ENV -Append
     }
 }

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -18,6 +18,8 @@ Get-PSResource -Name $requiredModules -Verbose:$false | Sort-Object -Property Na
 
 LogGroup "Loading environment variables:" {
     $envvar = $env:GITHUB_ACTION_INPUT_env
+    Write-Host "Environment variable:"
+    Write-Host $envvar
     $data = ConvertFrom-StringData -StringData $envvar -Delimiter ':'
     $data.GetEnumerator() | ForEach-Object {
         Write-Output "::add-mask::$($_.Value)"

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -17,7 +17,7 @@ Get-PSResource -Name $requiredModules -Verbose:$false | Sort-Object -Property Na
     Format-Table -Property Name, Version, Prerelease, Repository -AutoSize -Wrap
 
 LogGroup "Loading environment variables:" {
-    Get-ChildItem -Path env: | Where-Object { $_.Name -like 'GITHUB_ACTION_INPUT_*' } | ForEach-Object {
+    Get-ChildItem -Path env: | Where-Object { $_.Name -like 'GITHUB_ACTION_INPUT_env*' } | ForEach-Object {
         $name = $_.Name -replace '^GITHUB_ACTION_INPUT_'
         $value = $_.Value
         Write-Host "[$name] = [$value]"


### PR DESCRIPTION
## Description

- New input: `env`. 
  - This takes a multiline string input via a single env var that is parsed with ConvertTo-StringData with `:` as delimiter, and adds the key-value pairs as masked env vars on the current job in the workflow.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [x] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
