### PR TITLE
🩹 [Patch]: Use `Microsoft.PowerShell.PlatyPS` instead of `platyPS`

### DIFF
--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -3,12 +3,20 @@
 [CmdletBinding()]
 param()
 
-$requiredModules = 'Utilities', 'powershell-yaml', 'PSSemVer', 'Pester', 'PSScriptAnalyzer', 'Microsoft.PowerShell.PlatyPS'
+$requiredModules = 'Utilities', 'powershell-yaml', 'PSSemVer', 'Pester', 'PSScriptAnalyzer'
+$requiredPreviewModules = 'Microsoft.PowerShell.PlatyPS'
 
 $requiredModules | Sort-Object | ForEach-Object {
     $moduleName = $_
     LogGroup "Installing prerequisite: [$moduleName]" {
         Install-PSResource -Name $moduleName -TrustRepository -Repository PSGallery
+        Write-Verbose (Get-PSResource -Name $moduleName | Select-Object * | Out-String)
+    }
+}
+$requiredPreviewModules | Sort-Object | ForEach-Object {
+    $moduleName = $_
+    LogGroup "Installing prerequisite: [$moduleName] (prerelease)" {
+        Install-PSResource -Name $moduleName -TrustRepository -Repository PSGallery -Prerelease
         Write-Verbose (Get-PSResource -Name $moduleName | Select-Object * | Out-String)
     }
 }

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -8,7 +8,7 @@ $requiredModules = @{
     PSSemVer                       = @{}
     Pester                         = @{}
     PSScriptAnalyzer               = @{}
-    # PlatyPS                        = @{}
+    PlatyPS                        = @{}
     'Microsoft.PowerShell.PlatyPS' = @{
         Prerelease = $true
     }

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -8,7 +8,7 @@ $requiredModules = @{
     PSSemVer                       = @{}
     Pester                         = @{}
     PSScriptAnalyzer               = @{}
-    PlatyPS                        = @{}
+    # PlatyPS                        = @{}
     'Microsoft.PowerShell.PlatyPS' = @{
         Prerelease = $true
     }

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -3,7 +3,7 @@
 [CmdletBinding()]
 param()
 
-$requiredModules = 'Utilities', 'powershell-yaml', 'PSSemVer', 'Pester', 'PSScriptAnalyzer', 'platyPS'
+$requiredModules = 'Utilities', 'powershell-yaml', 'PSSemVer', 'Pester', 'PSScriptAnalyzer', 'Microsoft.PowerShell.PlatyPS'
 
 $requiredModules | Sort-Object | ForEach-Object {
     $moduleName = $_

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -2,22 +2,25 @@
 
 [CmdletBinding()]
 param()
-
-$requiredModules = 'Utilities', 'powershell-yaml', 'PSSemVer', 'Pester', 'PSScriptAnalyzer' #, 'PlatyPS'
-$requiredPreviewModules = 'Microsoft.PowerShell.PlatyPS'
-
-$requiredModules | Sort-Object | ForEach-Object {
-    $moduleName = $_
-    LogGroup "Installing prerequisite: [$moduleName]" {
-        Install-PSResource -Name $moduleName -TrustRepository -Repository PSGallery
-        Write-Verbose (Get-PSResource -Name $moduleName | Select-Object * | Out-String)
+$requiredModules = @{
+    Utilities                      = @{}
+    'powershell-yaml'              = @{}
+    PSSemVer                       = @{}
+    Pester                         = @{}
+    PSScriptAnalyzer               = @{}
+    PlatyPS                        = @{}
+    'Microsoft.PowerShell.PlatyPS' = @{
+        Prerelease = $true
     }
 }
-$requiredPreviewModules | Sort-Object | ForEach-Object {
-    $moduleName = $_
-    LogGroup "Installing prerequisite: [$moduleName] (prerelease)" {
-        Install-PSResource -Name $moduleName -TrustRepository -Repository PSGallery -Prerelease
-        Write-Verbose (Get-PSResource -Name $moduleName | Select-Object * | Out-String)
+
+$requiredModules.GetEnumerator() | Sort-Object | ForEach-Object {
+    $name = $_.Key
+    $settings = $_.Value
+    LogGroup "Installing prerequisite: [$name]" {
+        Install-PSResource -Name $name -TrustRepository -Repository PSGallery @settings
+        Write-Verbose (Get-PSResource -Name $name | Select-Object * | Out-String)
+        Write-Verbose (Get-Command -Module $name | Out-String)
     }
 }
 

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -8,7 +8,7 @@ $requiredModules = @{
     PSSemVer                       = @{}
     Pester                         = @{}
     PSScriptAnalyzer               = @{}
-    PlatyPS                        = @{}
+    # PlatyPS                        = @{}
     'Microsoft.PowerShell.PlatyPS' = @{
         Prerelease = $true
     }
@@ -24,5 +24,5 @@ $requiredModules.GetEnumerator() | Sort-Object | ForEach-Object {
     }
 }
 
-Get-PSResource -Name $requiredModules -Verbose:$false | Sort-Object -Property Name |
+$requiredModules.Keys | Get-InstalledPSResource -Verbose:$false | Sort-Object -Property Name |
     Format-Table -Property Name, Version, Prerelease, Repository -AutoSize -Wrap

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -3,7 +3,7 @@
 [CmdletBinding()]
 param()
 
-$requiredModules = 'Utilities', 'powershell-yaml', 'PSSemVer', 'Pester', 'PSScriptAnalyzer'
+$requiredModules = 'Utilities', 'powershell-yaml', 'PSSemVer', 'Pester', 'PSScriptAnalyzer' #, 'PlatyPS'
 $requiredPreviewModules = 'Microsoft.PowerShell.PlatyPS'
 
 $requiredModules | Sort-Object | ForEach-Object {


### PR DESCRIPTION
## Description

- Use `Microsoft.PowerShell.PlatyPS` instead of `platyPS`
- Needed by https://github.com/PSModule/Process-PSModule/issues/103

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
