### PR TITLE
🩹 [Patch]: Revert back to `PlatyPS` from `Microsoft.PowerShell.PlatyPS`

### DIFF
--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -8,10 +8,10 @@ $requiredModules = @{
     PSSemVer                       = @{}
     Pester                         = @{}
     PSScriptAnalyzer               = @{}
-    # PlatyPS                        = @{}
-    'Microsoft.PowerShell.PlatyPS' = @{
-        Prerelease = $true
-    }
+    PlatyPS                        = @{}
+    # 'Microsoft.PowerShell.PlatyPS' = @{
+    #     Prerelease = $true
+    # }
 }
 
 $requiredModules.GetEnumerator() | Sort-Object | ForEach-Object {

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -3,12 +3,12 @@
 [CmdletBinding()]
 param()
 $requiredModules = @{
-    Utilities                      = @{}
-    'powershell-yaml'              = @{}
-    PSSemVer                       = @{}
-    Pester                         = @{}
-    PSScriptAnalyzer               = @{}
-    PlatyPS                        = @{}
+    Utilities         = @{}
+    'powershell-yaml' = @{}
+    PSSemVer          = @{}
+    Pester            = @{}
+    PSScriptAnalyzer  = @{}
+    PlatyPS           = @{}
     # 'Microsoft.PowerShell.PlatyPS' = @{
     #     Prerelease = $true
     # }


### PR DESCRIPTION
## Description

- Revert back to `PlatyPS` from `Microsoft.PowerShell.PlatyPS`

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
