### PR TITLE
🩹 [Patch]: Update workflow triggers and doc action inputs

### DIFF
--- a/.github/workflows/Action-Test.yml
+++ b/.github/workflows/Action-Test.yml
@@ -2,7 +2,11 @@ name: Action-Test
 
 run-name: "Action-Test - [${{ github.event.pull_request.title }} #${{ github.event.pull_request.number }}] by @${{ github.actor }}"
 
-on: [pull_request]
+on:
+  workflow_dispatch:
+  pull_request:
+  schedule:
+    - cron: '0 0 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ The Initialize-PSModule action will prepare the runner for the PSModule framewor
 
 | Name | Description | Required | Default |
 | - | - | - | - |
-| `Debug` | Enable debug output. | false | `'false'` |
-| `Verbose` | Enable verbose output. | false | `'false'` |
-| `Version` | Specifies the version of the resource to be returned. | false |  |
-| `Prerelease` | Allow prerelease versions if available. | false | `'false'` |
+| `Debug` | Enable debug output. | `false` | `'false'` |
+| `Verbose` | Enable verbose output. | `false` | `'false'` |
+| `Version` | Specifies the version of the GitHub module to be installed. The value must be an exact version. | `false` | |
+| `Prerelease` | Allow prerelease versions if available. | `false` | `'false'` |
 
 ## Example
 

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
     required: false
     default: 'false'
   Version:
-    description: Specifies the version of the resource to be returned.
+    description: Specifies the version of the GitHub module to be installed. The value must be an exact version.
     required: false
   Prerelease:
     description: Allow prerelease versions if available.
@@ -34,4 +34,4 @@ runs:
         Version: ${{ inputs.Version }}
         Script: |
           # Initialize-PSModule
-          . "${{ github.action_path }}\scripts\main.ps1" -Verbose
+          . "${{ github.action_path }}\scripts\main.ps1"

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -2,6 +2,7 @@
 
 [CmdletBinding()]
 param()
+
 $requiredModules = @{
     Utilities         = @{}
     'powershell-yaml' = @{}


### PR DESCRIPTION
## Description


This pull request includes several changes to the GitHub Actions workflow, documentation, and action configuration files. The main changes are the addition of a scheduled trigger to the workflow, updates to the descriptions in the documentation and action configuration, and a minor update to the PowerShell script.

Workflow and scheduling updates:

* [`.github/workflows/Action-Test.yml`](diffhunk://#diff-a12ae5c885b0673c0ff6f70c2670886907590d624626e07da4c52e01aeaf56a4L5-R9): Added a scheduled trigger to the workflow to run it daily at midnight.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L39-R42): Updated the description for the `Version` input to specify that it refers to the version of the GitHub module to be installed.

Action configuration updates:

* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L18-R18): Updated the description for the `Version` input to specify that it refers to the version of the GitHub module to be installed.
* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L37-R37): Removed the `-Verbose` flag from the PowerShell script execution.

Script updates:

* [`scripts/main.ps1`](diffhunk://#diff-dc2e5a659836b1b73abb03421c567f5018c2755677c4a0aa764cb26117b68011R5): Added a blank line after the `param()` declaration for better readability.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
