### PR TITLE
🩹 [Patch]: Add MarkdownPS as it is not in the 2404 image.

### DIFF
--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -10,6 +10,7 @@ $requiredModules = @{
     Pester            = @{}
     PSScriptAnalyzer  = @{}
     PlatyPS           = @{}
+    MarkdownPS        = @{}
     # 'Microsoft.PowerShell.PlatyPS' = @{
     #     Prerelease = $true
     # }


### PR DESCRIPTION
## Description

This pull request includes a small change to the `scripts/main.ps1` file. The change adds the `MarkdownPS` module to the `$requiredModules` hashtable.

* [`scripts/main.ps1`](diffhunk://#diff-dc2e5a659836b1b73abb03421c567f5018c2755677c4a0aa764cb26117b68011R13): Added `MarkdownPS` to the `$requiredModules` hashtable.
  * Fixes #26 

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
