### PR TITLE
🩹 [Patch]: Add retry on Install-PSResource

### DIFF
--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -20,7 +20,21 @@ $requiredModules.GetEnumerator() | Sort-Object | ForEach-Object {
     $name = $_.Key
     $settings = $_.Value
     LogGroup "Installing prerequisite: [$name]" {
-        Install-PSResource -Name $name -TrustRepository -Repository PSGallery @settings
+        $Count = 5
+        $Delay = 10
+        for ($i = 0; $i -lt $Count; $i++) {
+            try {
+                Install-PSResource -Name $name -TrustRepository -Repository PSGallery @settings
+                break
+            } catch {
+                Write-Warning "Installing $name failed with error: $_"
+                if ($i -eq $Count - 1) {
+                    throw
+                }
+                Write-Warning "Retrying in $Delay seconds..."
+                Start-Sleep -Seconds $Delay
+            }
+        }
         Write-Verbose (Get-PSResource -Name $name | Select-Object * | Out-String)
         Write-Verbose (Get-Command -Module $name | Out-String)
     }

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -22,7 +22,7 @@ $requiredModules.GetEnumerator() | Sort-Object | ForEach-Object {
     LogGroup "Installing prerequisite: [$name]" {
         $Count = 5
         $Delay = 10
-        for ($i = 1; $i -lt $Count; $i++) {
+        for ($i = 1; $i -le $Count; $i++) {
             try {
                 Install-PSResource -Name $name -TrustRepository -Repository PSGallery @settings
                 break

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -27,11 +27,9 @@ $requiredModules.GetEnumerator() | Sort-Object | ForEach-Object {
                 Install-PSResource -Name $name -TrustRepository -Repository PSGallery @settings
                 break
             } catch {
-                Write-Warning "Installing $name failed with error: $_"
                 if ($i -eq $Count - 1) {
-                    throw
+                    throw $_
                 }
-                Write-Warning "Retrying in $Delay seconds..."
                 Start-Sleep -Seconds $Delay
             }
         }

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -35,8 +35,11 @@ $requiredModules.GetEnumerator() | Sort-Object | ForEach-Object {
                 Start-Sleep -Seconds $Delay
             }
         }
-        Write-Verbose (Get-PSResource -Name $name | Select-Object * | Out-String)
-        Write-Verbose (Get-Command -Module $name | Out-String)
+        Write-Host "Installed module: [$name]"
+        Write-Host (Get-PSResource -Name $name | Select-Object * | Out-String)
+
+        Write-Host "Module commands:"
+        Write-Host (Get-Command -Module $name | Out-String)
     }
 }
 

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -22,12 +22,12 @@ $requiredModules.GetEnumerator() | Sort-Object | ForEach-Object {
     LogGroup "Installing prerequisite: [$name]" {
         $Count = 5
         $Delay = 10
-        for ($i = 0; $i -lt $Count; $i++) {
+        for ($i = 1; $i -lt $Count; $i++) {
             try {
                 Install-PSResource -Name $name -TrustRepository -Repository PSGallery @settings
                 break
             } catch {
-                if ($i -eq $Count - 1) {
+                if ($i -eq $Count) {
                     throw $_
                 }
                 Start-Sleep -Seconds $Delay


### PR DESCRIPTION
## Description

This pull request includes a change to the `scripts/main.ps1` introducing a retry mechanism for the `Install-PSResource` command to handle intermittent failures more gracefully.

Improvements to installation process:

* [`scripts/main.ps1`](diffhunk://#diff-dc2e5a659836b1b73abb03421c567f5018c2755677c4a0aa764cb26117b68011R23-R37): Added retry logic with a maximum of 5 attempts and a 10-second delay between attempts to the `Install-PSResource` command. This change helps ensure that temporary issues do not cause the entire installation process to fail.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
