### PR TITLE
🩹 [Patch]: Show all installed modules in summary

### DIFF
--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -43,5 +43,5 @@ $requiredModules.GetEnumerator() | Sort-Object | ForEach-Object {
     }
 }
 
-$requiredModules.Keys | Get-InstalledPSResource -Verbose:$false | Sort-Object -Property Name |
+Get-InstalledPSResource -Verbose:$false | Sort-Object -Property Name |
     Format-Table -Property Name, Version, Prerelease, Repository -AutoSize | Out-String


### PR DESCRIPTION
## Description

This pull request includes a small change to the `scripts/main.ps1` file. The change simplifies the command by removing the unnecessary enumeration of `$requiredModules.Keys` before calling `Get-InstalledPSResource`.

* [`scripts/main.ps1`](diffhunk://#diff-dc2e5a659836b1b73abb03421c567f5018c2755677c4a0aa764cb26117b68011L46-R46): Simplified the command by removing `$requiredModules.Keys` before calling `Get-InstalledPSResource`.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
