### PR TITLE
🩹 [Patch]: Remove GITHUB_TOKEN environment variable from Auto-Release

### DIFF
--- a/.github/workflows/Auto-Release.yml
+++ b/.github/workflows/Auto-Release.yml
@@ -30,7 +30,5 @@ jobs:
 
       - name: Auto-Release
         uses: PSModule/Auto-Release@v1
-        env:
-          GITHUB_TOKEN: ${{ github.token }} # Used for GitHub CLI authentication
         with:
           IncrementalPrerelease: false


### PR DESCRIPTION
## Description

This pull request includes a small change to the `.github/workflows/Auto-Release.yml` file. The change removes the `env` section which contained the `GITHUB_TOKEN` used for GitHub CLI authentication.

* [`.github/workflows/Auto-Release.yml`](diffhunk://#diff-d3f6900ee5159d4bc4ba6d893e2dd8443c2691b0490d7351cffbd7a37ed8d95aL33-L34): Removed the `env` section with the `GITHUB_TOKEN` used for GitHub CLI authentication.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
