### PR TITLE
⚙️ [Maintenance]: Align workflows across action repositories

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -28,7 +28,7 @@ jobs:
   Release:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Code
+      - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -21,8 +21,8 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: write # Required to create releases
+  pull-requests: write # Required to create comments on the PRs
 
 jobs:
   Release:
@@ -34,6 +34,4 @@ jobs:
           persist-credentials: false
 
       - name: Release
-        uses: PSModule/Release-GHRepository@88c70461c8f16cc09682005bcf3b7fca4dd8dc1a # v2.0.1
-        with:
-          IncrementalPrerelease: false
+        uses: PSModule/Release-GHRepository@5a5165d66f485d1aad217ef34a190178b214fdcb # v2.0.2


### PR DESCRIPTION
This pull request makes minor updates to the GitHub Actions workflow for releases, focusing on improving clarity and keeping dependencies up to date.

- Workflow clarity:
  * Added comments to the `permissions` section in `.github/workflows/Release.yml` to clarify why each permission is needed.
  * Renamed the checkout step from "Checkout Code" to "Checkout repo" for better readability.

- Dependency updates:
  * Updated the `actions/checkout` action to a specific commit for version `v6.0.2`.
  * Updated the `PSModule/Release-GHRepository` action from version `v2.0.1` to `v2.0.2` for the release step.